### PR TITLE
Improve history (queue) loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.1] - 17-04-2021
+## [1.3.2] - 07-06-2021
 ### Added
 - System.Runtime dependency
 - Improved logging in the weather client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.1] - 17-04-2021
 ### Added
+- System.Runtime dependency
+- Improved logging in the weather client
+
+### Updated
+- Project dependencies
+- Platform queueing
+
+## [1.3.1] - 17-04-2021
+### Added
 - Additional logging
 
 ### Updated

--- a/SensateIoT.SmartEnergy.Dsmr.Processor.Common/SensateIoT.SmartEnergy.Dsmr.Processor.Common.csproj
+++ b/SensateIoT.SmartEnergy.Dsmr.Processor.Common/SensateIoT.SmartEnergy.Dsmr.Processor.Common.csproj
@@ -40,8 +40,14 @@
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.4.3.1\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/SensateIoT.SmartEnergy.Dsmr.Processor.Common/Services/WeatherService.cs
+++ b/SensateIoT.SmartEnergy.Dsmr.Processor.Common/Services/WeatherService.cs
@@ -38,7 +38,6 @@ namespace SensateIoT.SmartEnergy.Dsmr.Processor.Common.Services
 				}, ct).ConfigureAwait(false);
 
 				if(result.Id == 0) {
-					logger.Warn("Unable to lookup weather.");
 					return null;
 				}
 

--- a/SensateIoT.SmartEnergy.Dsmr.Processor.Common/packages.config
+++ b/SensateIoT.SmartEnergy.Dsmr.Processor.Common/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net48" />
+  <package id="System.Runtime" version="4.3.1" targetFramework="net48" />
 </packages>

--- a/SensateIoT.SmartEnergy.Dsmr.Processor.DataAccess/Repositories/ProcessingHistoryRepository.cs
+++ b/SensateIoT.SmartEnergy.Dsmr.Processor.DataAccess/Repositories/ProcessingHistoryRepository.cs
@@ -22,20 +22,23 @@ namespace SensateIoT.SmartEnergy.Dsmr.Processor.DataAccess.Repositories
 
 		public async Task<ProcessingTimestamp> GetLastProcessingTimestamp(int sensorId)
 		{
-			var result = await this.QuerySingleAsync<ProcessingTimestamp>(DsmrProcessor_SelectLastProcessedBySensorId,
-				"@sensorId", sensorId).ConfigureAwait(false);
+			return await this.QuerySingleAsync<ProcessingTimestamp>(
+				DsmrProcessor_SelectLastProcessedBySensorId,
+				"@sensorId",
+				sensorId
+			).ConfigureAwait(false) ?? this.createDefault(sensorId);
+		}
 
-			if(result == null) {
-				var now = this.m_clock.GetCurrentTime();
+		private ProcessingTimestamp createDefault(int id)
+		{
+			var now = this.m_clock.GetCurrentTime();
+			var start = now.AddDays(-2);
 
-				result = new ProcessingTimestamp {
-					End = new DateTime(now.Year, now.Month, now.Day, 0, 0, 0, DateTimeKind.Utc),
-					SensorId = sensorId,
-					Start = DateTime.MinValue
-				};
-			}
-
-			return result;
+			return new ProcessingTimestamp {
+				End = new DateTime(start.Year, start.Month, start.Day, 0, 0, 0, DateTimeKind.Utc),
+				SensorId = id,
+				Start = DateTime.MinValue
+			};
 		}
 
 		public async Task CreateProcessingTimestamp(int sensorId, int count, DateTime start, DateTime end, CancellationToken ct)

--- a/SensateIoT.SmartEnergy.Dsmr.Processor.Service/Properties/AssemblyInfo.cs
+++ b/SensateIoT.SmartEnergy.Dsmr.Processor.Service/Properties/AssemblyInfo.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.1.0")]
-[assembly: AssemblyFileVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.3.2.0")]
+[assembly: AssemblyFileVersion("1.3.2.0")]


### PR DESCRIPTION
Improve recovery from (longer) outages by recovering up to two days (full 48 hours) of data. In the old
situation at most 24 hours is recovered (reload from the start of the day). Logging for failed weather lookups
has been improved by logging the full response when a lookup has failed.